### PR TITLE
Compatiblity with gdcc 0.12.0

### DIFF
--- a/pk3_builder.bat
+++ b/pk3_builder.bat
@@ -29,16 +29,16 @@ if %ERRORLEVEL%==4 exit
 if %ERRORLEVEL%==5 exit
 exit
 
-:compile_chasecam
-set PROJECT_FOLDER=project_chasecam
-set PROJECT_NAME=chasecam
-set PROJECT_LIBNAME=chasecam
-goto build
-
 :compile_flashlight
 set PROJECT_FOLDER=project_flashlight
 set PROJECT_NAME=flashlight
 set PROJECT_LIBNAME=f_light
+goto build
+
+:compile_chasecam
+set PROJECT_FOLDER=project_chasecam
+set PROJECT_NAME=chasecam
+set PROJECT_LIBNAME=chasecam
 goto build
 
 :compile_footsteps

--- a/pk3_builder.bat
+++ b/pk3_builder.bat
@@ -70,22 +70,20 @@ if not exist ".\%PROJECT_FOLDER%\source\bin\libgdcc" mkdir ".\%PROJECT_FOLDER%\s
 if not exist ".\%PROJECT_FOLDER%\pk3\acs" mkdir ".\%PROJECT_FOLDER%\pk3\acs"
 if not exist ".\%PROJECT_FOLDER%\source\inc" mkdir ".\%PROJECT_FOLDER%\source\inc"
 if not exist ".\%PROJECT_FOLDER%\source\src" mkdir ".\%PROJECT_FOLDER%\source\src"
-echo ZDACS-asm.ir
-%AS% --bc-target=ZDoom -o ".\%PROJECT_FOLDER%\source\bin\libgdcc\ZDACS-asm.ir" .\GDCC\lib\src\libGDCC\ZDACS\*.asm
-echo c.ir
-%CC% --bc-target=ZDoom -o ".\%PROJECT_FOLDER%\source\bin\libgdcc\c.ir" .\GDCC\lib\src\libGDCC\*.c
-echo libGDCC.ir
-%LD% -c --bc-target=ZDoom -o ".\%PROJECT_FOLDER%\source\bin\libgdcc\libGDCC.ir" ".\%PROJECT_FOLDER%\source\bin\libgdcc\*.ir"
-echo libc.ir
-%CC% --bc-target=ZDoom -o ".\%PROJECT_FOLDER%\source\bin\libgdcc\libc.ir" .\GDCC\lib\src\libc\*.c
+
+echo Makelib...
+.\gdcc\gdcc-makelib --bc-target ZDoom libGDCC -c -o ".\%PROJECT_FOLDER%\source\bin\libgdcc\libGDCC.ir"
+.\gdcc\gdcc-makelib --bc-target ZDoom libc    -c -o ".\%PROJECT_FOLDER%\source\bin\libgdcc\libc.ir"
+
 echo %PROJECT_LIBNAME%.ir
-if %ZANDRONUM_COMPILE%==1 %CC% -ibase\inc -i"%PROJECT_FOLDER%\source\inc" --bc-target=ZDoom -DZAN_ACS -o ".\%PROJECT_FOLDER%\source\bin\%PROJECT_LIBNAME%.ir" ".\%PROJECT_FOLDER%\source\src\*.c" .\base\src\*.c
+if %ZANDRONUM_COMPILE%==1 %CC% --bc-target ZDoom -DZAN_ACS ".\%PROJECT_FOLDER%\source\src\*.c" .\base\src\*.c -ibase\inc -i "%PROJECT_FOLDER%\source\inc" -c -o ".\%PROJECT_FOLDER%\source\bin\%PROJECT_LIBNAME%.ir"
 if not %ZANDRONUM_COMPILE%==1 (
-	if %ZANDRONUM_COMPAT%==1 %CC% -ibase\inc -i"%PROJECT_FOLDER%\source\inc" --bc-target=ZDoom -DZAN_COMPAT -o ".\%PROJECT_FOLDER%\source\bin\%PROJECT_LIBNAME%.ir" ".\%PROJECT_FOLDER%\source\src\*.c" .\base\src\*.c
-	if not %ZANDRONUM_COMPAT%==1 %CC% -ibase\inc -i"%PROJECT_FOLDER%\source\inc" --bc-target=ZDoom -o ".\%PROJECT_FOLDER%\source\bin\%PROJECT_LIBNAME%.ir" ".\%PROJECT_FOLDER%\source\src\*.c" .\base\src\*.c
+	if %ZANDRONUM_COMPAT%==1 %CC% --bc-target ZDoom -DZAN_COMPAT ".\%PROJECT_FOLDER%\source\src\*.c" .\base\src\*.c -ibase\inc -i "%PROJECT_FOLDER%\source\inc" -c -o ".\%PROJECT_FOLDER%\source\bin\%PROJECT_LIBNAME%.ir"
+	if not %ZANDRONUM_COMPAT%==1 %CC% --bc-target ZDoom ".\%PROJECT_FOLDER%\source\src\*.c" .\base\src\*.c -ibase\inc -i "%PROJECT_FOLDER%\source\inc" -c -o ".\%PROJECT_FOLDER%\source\bin\%PROJECT_LIBNAME%.ir"
 )
-echo %PROJECT_LIBNAME%.bin
-%LD% --bc-target=ZDoom -o ".\%PROJECT_FOLDER%\pk3\acs\%PROJECT_LIBNAME%.bin" ".\%PROJECT_FOLDER%\source\bin\*.ir" ".\%PROJECT_FOLDER%\source\bin\libgdcc\*.ir"
+echo %PROJECT_LIBNAME%.o
+%LD% --bc-target ZDoom ".\%PROJECT_FOLDER%\source\bin\%PROJECT_LIBNAME%.ir" ".\%PROJECT_FOLDER%\source\bin\*.ir" ".\%PROJECT_FOLDER%\source\bin\libgdcc\*.ir" -o ".\%PROJECT_FOLDER%\pk3\acs\%PROJECT_LIBNAME%.o"
+
 echo Finished.
 echo.
 

--- a/project_footsteps/pk3/cvarinfo.txt
+++ b/project_footsteps/pk3/cvarinfo.txt
@@ -1,3 +1,4 @@
 // CVar Info
+server int fs_enabled = 1;
 server float fs_volume_mul = 1.0;
 server float fs_delay_mul = 1.0;

--- a/project_footsteps/pk3/menudef.txt
+++ b/project_footsteps/pk3/menudef.txt
@@ -1,0 +1,14 @@
+AddOptionMenu "OptionsMenu"
+{
+	Submenu "Footsteps Options", "FootstepOptions"
+}
+
+OptionMenu "FootstepOptions"
+{
+title "Footstep Options"
+
+StaticText " "
+Option  "Enabled", "fs_enabled","OnOff"
+Slider "Delay",	"fs_delay_mul",0.0,1.0,0.1
+Slider "Volume", "fs_volume_mul",0.0,1.0,0.1
+}

--- a/project_footsteps/source/src/main.c
+++ b/project_footsteps/source/src/main.c
@@ -39,7 +39,7 @@ Z_SCRIPT(SCR_FOOTSTEPS) ENTER void Footsteps (void)
 
 	while (true)
 	{
-		if (!(ACS_GetActorZ(0) - ACS_GetActorFloorZ(0)))
+		if (ACS_GetCVar(s"fs_enabled") > 0 && !(ACS_GetActorZ(0) - ACS_GetActorFloorZ(0)))
 		{
 			flat = ACSStrToChar(ACS_StrParam("%LS", s"STEP_FLATS"));
 			token = strtok(flat, ":");

--- a/project_footsteps/source/src/main.c
+++ b/project_footsteps/source/src/main.c
@@ -15,16 +15,16 @@ int ZanSqrt (int number)
 {
 	if (number <= 3)
 		return number > 0;
-	
+
 	int oldAns = number >> 1,
 	newAns = (oldAns + number / oldAns) >> 1;
-	
+
 	while (newAns < oldAns)
 	{
 		oldAns = newAns;
 		newAns = (oldAns + number / oldAns) >> 1;
 	}
-	
+
 	return oldAns;
 }
 
@@ -36,16 +36,17 @@ Z_SCRIPT(SCR_FOOTSTEPS) ENTER void Footsteps (void)
 	__str langdef, sound;
 	accum volume, vx, vy, speed;
 	int delay;
-	
+
 	while (true)
 	{
 		if (!(ACS_GetActorZ(0) - ACS_GetActorFloorZ(0)))
 		{
 			flat = ACSStrToChar(ACS_StrParam("%LS", s"STEP_FLATS"));
 			token = strtok(flat, ":");
-			
+
 			vx = ACS_GetActorVelX(0);
 			vy = ACS_GetActorVelY(0);
+
 			#ifdef ZAN_ACS
 			// Zandronum doesn't support FixedSqrt yet, so
 			// we'll need to use a custom function.
@@ -53,26 +54,27 @@ Z_SCRIPT(SCR_FOOTSTEPS) ENTER void Footsteps (void)
 			#else
 			speed = ACS_FixedSqrt(vx * vx + vy * vy) / 16k;
 			#endif
-			
+
 			if (speed > 1k)
 				speed = 1k;
-			
+
 			delay = (35k - (25 * speed)) * ACS_GetCVarFixed(s"fs_delay_mul");
 			volume = speed * ACS_GetCVarFixed(s"fs_volume_mul");
-			
+
 			while (token != NULL)
 			{
 				if (ACS_CheckActorFloorTexture(0, ctoacstr(token)))
 				{
-					langdef = ACS_StrParam("STEP_%S", ctoacstr(token));
+					langdef = ACS_StrParam("STEP_%s", token);
 					sound = ACS_StrParam("%LS", langdef);
-					if (!ACS_StrICmp(langdef, sound))
+
+					if (!ACS_StrICmp(langdef, sound)){
 						sound = ACS_StrParam("%LS", s"STEP_DEFAULT");
+					}
 				}
 				token = strtok(NULL, ":");
 			}
-			
-			ACS_ActivatorSound(sound, (127k * volume) >> 16);
+			ACS_ActivatorSound(sound, (127k * volume));
 			sound = ACS_StrParam("%LS", s"STEP_DEFAULT");
 		}
 		if (delay > 1)

--- a/readme.md
+++ b/readme.md
@@ -6,5 +6,6 @@ ZK-Resources uses GDCC to compile its source code. GDCC is open-source software,
 3. Wherever you extracted the zip, there should be a folder called "zk-resources-master". Inside are all the files you will need.
 4. Make a new folder inside the "zk-resources-master" folder called "GDCC" (if it doesn't exist already).
 5. Download the latest version of GDCC from [here](https://www.dropbox.com/sh/e4msp35vxp61ztg/AAALcmttOua20tkcs82NoElWa). The latest version will always be at the bottom. Get either the "Win32" or "Win64" version depending on your computer.
+NOTE: This has been tested with GDCC 0.12.0.
 6. Extract the archive to the GDCC folder that you just created.
 7. Now all you need to do is open "pk3_builder.bat" and follow the prompts.


### PR DESCRIPTION
Fixed project not compiling under latest gdcc versions (tested up to version 0.12.0).

The later gdcc versions improve compatibility with newer ZDoom versions. This is the reason footsteps could not be heard in the PSX TC, for example.

Perhaps this will help future users that want to use or extend this resource.